### PR TITLE
fix(editor): reset global and local properties to defaults when picking a new card

### DIFF
--- a/src/tabbed-card-editor.ts
+++ b/src/tabbed-card-editor.ts
@@ -149,6 +149,11 @@ export class TabbedCardEditor extends LitElement {
 
     fireEvent(this, "config-changed", { config: this._config });
     this._fireSelectedTabEvent();
+
+    this._localConfigTabSelection = 0;
+    this._globalConfigTabSelection = 0;
+    this._isLocalConfigExpanded = false;
+    this._isGlobalConfigExpanded = false;
   }
 
   protected _handleDeleteCard() {


### PR DESCRIPTION
fixes: https://github.com/kinghat/tabbed-card/issues/74