### PR TITLE
feature: set-picked-card-label

### DIFF
--- a/src/tabbed-card-editor.ts
+++ b/src/tabbed-card-editor.ts
@@ -142,7 +142,13 @@ export class TabbedCardEditor extends LitElement {
     if (!this._config) return;
 
     const cardConfig = ev.detail.config;
-    const tabs = [...this._config.tabs, { card: cardConfig }];
+    const newTab = {
+      card: cardConfig,
+      attributes: {
+        label: `New Tab ${this._tabSelection}`,
+      },
+    };
+    const tabs = [...this._config.tabs, newTab];
 
     this._config = { ...this._config, tabs };
 


### PR DESCRIPTION
instead of leaving the tab label blank when picking a card, set a label value of "New Tab N", with N being the new tabs index value.

discussion reference: https://github.com/kinghat/tabbed-card/discussions/27#discussioncomment-4681034