### PR TITLE
fix(tabs): ensure tab component is loaded

### DIFF
--- a/src/tabbed-card.ts
+++ b/src/tabbed-card.ts
@@ -61,6 +61,8 @@ export class TabbedCard extends LitElement {
 
   private async loadCardHelpers() {
     this._helpers = await (window as any).loadCardHelpers();
+
+    if (!customElements.get("mwc-tab-bar")) this._helpers.importMoreInfoControl("weather")
   }
 
   static async getConfigElement(): Promise<LovelaceCardEditor> {


### PR DESCRIPTION
ha frontend [v2023.9.0](https://github.com/home-assistant/core/releases/tag/2023.9.0) stopped loading `mwc-tab-bar` via whatever component it was being loaded by so it needs to be loaded manually