### PR TITLE
fix(tabs): ensure tab component is loaded (cherry-pick)

### DIFF
--- a/src/tabbed-card.ts
+++ b/src/tabbed-card.ts
@@ -65,6 +65,8 @@ export class TabbedCard extends LitElement {
 
   private async loadCardHelpers() {
     this._helpers = await (window as any).loadCardHelpers();
+
+    if (!customElements.get("mwc-tab-bar")) this._helpers.importMoreInfoControl("weather")
   }
 
   static async getConfigElement(): Promise<LovelaceCardEditor> {


### PR DESCRIPTION
ha frontend stopped loading mwc-tab-bar via whatever component so it needs to be loaded manually
(cherry-pick)