### PR TITLE
Use relative colors to support themes

### DIFF
--- a/src/tabbed-card.ts
+++ b/src/tabbed-card.ts
@@ -56,8 +56,8 @@ export class TabbedCard extends LitElement {
   @state() private _tabs!: Tab[];
   @property() protected _styles = {
     "--mdc-theme-primary": "var(--primary-text-color)", // Color of the activated tab's text, indicator, and ripple.
-    "--mdc-tab-text-label-color-default: rgba(from var(--primary-text-color) r g b / 0.8)", // Color of an unactivated tab label.
-    "--mdc-tab-color-default: rgba(from var(--primary-text-color) r g b / 0.7)", // Color of an unactivated icon.
+    "--mdc-tab-text-label-color-default": "rgba(from var(--primary-text-color) r g b / 0.8)", // Color of an unactivated tab label.
+    "--mdc-tab-color-default": "rgba(from var(--primary-text-color) r g b / 0.7)", // Color of an unactivated icon.
     "--mdc-typography-button-font-size": "14px",
   };
 

--- a/src/tabbed-card.ts
+++ b/src/tabbed-card.ts
@@ -56,9 +56,8 @@ export class TabbedCard extends LitElement {
   @state() private _tabs!: Tab[];
   @property() protected _styles = {
     "--mdc-theme-primary": "var(--primary-text-color)", // Color of the activated tab's text, indicator, and ripple.
-    "--mdc-tab-text-label-color-default":
-      "rgba(var(--rgb-primary-text-color), 0.8)", // Color of an unactivated tab label.
-    "--mdc-tab-color-default": "rgba(var(--rgb-primary-text-color), 0.7)", // Color of an unactivated icon.
+    "--mdc-tab-text-label-color-default: rgba(from var(--primary-text-color) r g b / 0.8)", // Color of an unactivated tab label.
+    "--mdc-tab-color-default: rgba(from var(--primary-text-color) r g b / 0.7)", // Color of an unactivated icon.
     "--mdc-typography-button-font-size": "14px",
   };
 


### PR DESCRIPTION
Use [Relative colors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to support themes like [Material You theme](https://github.com/Nerwyn/material-you-theme).

Currently the text of the non-selected tabs is not readable:
<img width="732" alt="Image" src="https://github.com/user-attachments/assets/520255ab-7d7c-44ae-8c05-de074ef2b3a5" />

We need a gray color here like in the default theme:
<img width="732" alt="Image" src="https://github.com/user-attachments/assets/45bffc8d-1d5d-4519-8d81-903e09fdc4e4" />


Thanks to @Nerwyn for providing this fix in https://github.com/Nerwyn/material-you-utilities/issues/15#issuecomment-2881969934

